### PR TITLE
Add 2017.11 Meta-release

### DIFF
--- a/releases/2017.11.yml
+++ b/releases/2017.11.yml
@@ -1,0 +1,15 @@
+---
+  meta-release:
+    name: 2017.11
+    description: |
+      November 2017 Meta Release
+    components:
+      - name: rpc-openstack
+        url: https://github.com/rcbops/rpc-openstack
+        version: r14.4.0
+      - name: rpc-maas
+        url: https://github.com/rcbops/rpc-maas
+        version: 1.2.3
+      - name: rpc-ceph
+        url: https://github.com/rcbops/rpc-ceph
+        version: 0.0.1


### PR DESCRIPTION
This release updates rpc-openstack and rpc-maas, and introduces
a new project to the meta-release: rpc-ceph.