### PR TITLE
RE-1513 Reverse release order

### DIFF
--- a/components/rpc-ceph.yml
+++ b/components/rpc-ceph.yml
@@ -3,20 +3,20 @@ name: rpc-ceph
 releases:
 - series: master
   versions:
-  - sha: 5ac165fa15855550e4fc3bcbba7e88b7e22bfcbb
-    version: 0.0.1
-  - sha: c1fe3459eeeedec8bde9eeda14058e509d7db3de
-    version: 0.0.2
-  - sha: c8d3687803c161c8d9ecf8a981b0b4d0ace9f042
-    version: 0.0.3
-  - sha: 3f4be33cdaffc5503ac8f17e0f6fe85a373c7a8b
-    version: 1.0.0
-  - sha: 871ae784126bea2eb783420d5b410e0dbe3945c6
-    version: 1.1.0
-  - sha: 13cf219b4c3f4eed104acc30f5f05fb39a3d6b8d
-    version: 1.1.1
-  - sha: 50acd0e9c44f46d43c418902ba62262a99a93c7f
-    version: 1.1.2
   - sha: 90fe967b8a203782b497865ade49be577d6558c0
     version: 1.1.3
+  - sha: 50acd0e9c44f46d43c418902ba62262a99a93c7f
+    version: 1.1.2
+  - sha: 13cf219b4c3f4eed104acc30f5f05fb39a3d6b8d
+    version: 1.1.1
+  - sha: 871ae784126bea2eb783420d5b410e0dbe3945c6
+    version: 1.1.0
+  - sha: 3f4be33cdaffc5503ac8f17e0f6fe85a373c7a8b
+    version: 1.0.0
+  - sha: c8d3687803c161c8d9ecf8a981b0b4d0ace9f042
+    version: 0.0.3
+  - sha: c1fe3459eeeedec8bde9eeda14058e509d7db3de
+    version: 0.0.2
+  - sha: 5ac165fa15855550e4fc3bcbba7e88b7e22bfcbb
+    version: 0.0.1
 repo_url: https://github.com/rcbops/rpc-ceph

--- a/components/rpc-component-1.yml
+++ b/components/rpc-component-1.yml
@@ -3,8 +3,8 @@ name: rpc-component-1
 releases:
 - series: master
   versions:
-  - sha: 4e47e7232fc456bc9277526c39831b1450fe50de
-    version: 1.0.0
   - sha: 7a0b674ad92aa0e63f185a1aaa7830c584b9c123
     version: 1.0.1
+  - sha: 4e47e7232fc456bc9277526c39831b1450fe50de
+    version: 1.0.0
 repo_url: https://github.com/mattt416/rpc-component-1

--- a/components/rpc-component-2.yml
+++ b/components/rpc-component-2.yml
@@ -3,8 +3,8 @@ name: rpc-component-2
 releases:
 - series: master
   versions:
-  - sha: 76ee8bcd8862e4fb7c48e40fbf8110df80bd747c
-    version: 1.0.0
   - sha: 7646f1d0ef46b997fa976efb1faa99c47b2e6cb4
     version: 1.0.1
+  - sha: 76ee8bcd8862e4fb7c48e40fbf8110df80bd747c
+    version: 1.0.0
 repo_url: https://github.com/mattt416/rpc-component-2

--- a/components/rpc-maas.yml
+++ b/components/rpc-maas.yml
@@ -3,36 +3,36 @@ name: rpc-maas
 releases:
 - series: master
   versions:
-  - sha: 8bff00061c38559301c72321865824aff7b8edcf
-    version: 1.0.0
-  - sha: b9b0c69ff114c8f65aa20986086593f068755221
-    version: 1.1.0
-  - sha: dd7e17fb29f960c5548b50d61dd89d8353662ff6
-    version: 1.1.1
-  - sha: 2d8c1bcf12979524cbb27921ffabddb9e64ced9d
-    version: 1.1.2
-  - sha: 19b38e87f9739f75f39b1510dfb4e887955b9c5b
-    version: 1.2.0
-  - sha: afd68a809b9c09bb14ee449cedbdefd8abdb4bd8
-    version: 1.2.1
-  - sha: aaa614ec29230c47d25f7436018d8ed0489b5ecb
-    version: 1.2.2
-  - sha: 9cffced341d1d12ae2f349021bcbabe289e3d787
-    version: 1.3.0
-  - sha: 4547177f98ac62337aeda5c45966437acae16c84
-    version: 1.3.1
-  - sha: b157e762441e9d12a3629b5943ba51a6d2b10bbc
-    version: 1.4.0
-  - sha: 040b13b73727bfce11f60e9e6e044750119ff084
-    version: 1.5.0
-  - sha: 8ef6a97aff976d464e2087a6470aed91fd25a738
-    version: 1.6.0
-  - sha: 200ee30453f284f630495f03651ab55babc34184
-    version: 1.7.0
-  - sha: 765c204d6ec9cbb74d0c938fc938b67817d84ea6
-    version: 1.7.1
-  - sha: 101b2a732f382f702e53d283efc6b7ee99af48bf
-    version: 1.7.2
   - sha: 199870ba2e5dab4def6a3d862ebd5d50623a086d
     version: 1.7.3
+  - sha: 101b2a732f382f702e53d283efc6b7ee99af48bf
+    version: 1.7.2
+  - sha: 765c204d6ec9cbb74d0c938fc938b67817d84ea6
+    version: 1.7.1
+  - sha: 200ee30453f284f630495f03651ab55babc34184
+    version: 1.7.0
+  - sha: 8ef6a97aff976d464e2087a6470aed91fd25a738
+    version: 1.6.0
+  - sha: 040b13b73727bfce11f60e9e6e044750119ff084
+    version: 1.5.0
+  - sha: b157e762441e9d12a3629b5943ba51a6d2b10bbc
+    version: 1.4.0
+  - sha: 4547177f98ac62337aeda5c45966437acae16c84
+    version: 1.3.1
+  - sha: 9cffced341d1d12ae2f349021bcbabe289e3d787
+    version: 1.3.0
+  - sha: aaa614ec29230c47d25f7436018d8ed0489b5ecb
+    version: 1.2.2
+  - sha: afd68a809b9c09bb14ee449cedbdefd8abdb4bd8
+    version: 1.2.1
+  - sha: 19b38e87f9739f75f39b1510dfb4e887955b9c5b
+    version: 1.2.0
+  - sha: 2d8c1bcf12979524cbb27921ffabddb9e64ced9d
+    version: 1.1.2
+  - sha: dd7e17fb29f960c5548b50d61dd89d8353662ff6
+    version: 1.1.1
+  - sha: b9b0c69ff114c8f65aa20986086593f068755221
+    version: 1.1.0
+  - sha: 8bff00061c38559301c72321865824aff7b8edcf
+    version: 1.0.0
 repo_url: https://github.com/rcbops/rpc-maas

--- a/gating/check/run
+++ b/gating/check/run
@@ -7,7 +7,7 @@ which python3 || { apt-get update; apt-get install -y python3-minimal; }
 
 virtualenv --python python3 .venv3
 set +x; . .venv3/bin/activate; set -x
-pip install git+https://github.com/rcbops/rpc_component@776c7d7ddc96fd62b503c78c980256906db5a6fd#egg=rpc_component
+pip install git+https://github.com/rcbops/rpc_component@85f152ece9eee3c9cd7d68bd2ecc5982e17400ae#egg=rpc_component
 
 component_count=0
 non_component_count=0


### PR DESCRIPTION
rpc_component has been modified so that component files now expect
releases to be in the reverse order to reduce the likelihood of merge
conflicts. This change updates the component files and the version of
rpc_component used by the check.