### PR TITLE
Update README.md to detail component metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,40 @@
 # Releases
-This repository stores RPC meta-releases.
 
-Each release is represented by a file in [releases/](releases).
-This file contains the name of the release, description and a list of all
-the components included in the release.
+**NOTE**: as of 2018.08, meta-release metadata will no longer be stored in [releases/](releases). This system has been replaced by the component metadata system described below. The original readme has been moved to the [releases/](releases) directory for reference.
 
-## Release file specification
-Name must match the following regex: `YYYY\.MM?\.yml`
+---
 
+This repository stores metadata about RPC component releases.
+
+Each component is represented by a file in [components/](components).
+This file contains the name of the component, description and a list of all
+released versions of the component.
+
+## Component file specification
 The file is yaml, so should begin `---`
 
-The yaml document should be a dictionary with single top level key: **meta-release**. Meta-relase should be a dictionary with three keys:
-  * **name**: String, name of the release, should be the filename without `.yml`
-  * **description**: String, free form text describing the release
-  * **components**: List of every component included in the release
-    Each item in the list must be a dictionary with three keys:
-      * **name**: Name of the component
-      * **url**: Url to the repo or artifact for that component
-      * **version**: Version of the component included with this release.
+The yaml document contains a number of top-level entries:
+  * **is_product**: true/false
+  * **name**: String, name of the component, usually the filename without `.yml`
+  * **repo_url**: The URL of the repository where the code for this component is stored
+  * **releases**: Dictionary containing at least one **series** entry
+      * **series**: Name of the component series (e.g. ```master```)
+      * **versions**: Dictionary containing information about the released versions
+        * **sha**: sha of the released version
+        * **version**: version number of the released version
 
 Example:
 ```
 ---
-  meta-release:
-    name: 2017.8
-    description: |
-      The first RPC meta-release :)
-    components:
-      - name: rpc-openstack
-        url: https://github.com/rcbops/rpc-openstack
-        version: r14.1.1
-      - name: rpc-maas
-        url: https://github.com/rcbops/rpc-maas
-        version: 1.0.0
+is_product: false
+name: rpc-component-2
+releases:
+- series: master
+  versions:
+  - sha: 8fdcb3e99a71e1eeb0014484bb6492078402e563
+    version: 1.0.2
+  - sha: 7646f1d0ef46b997fa976efb1faa99c47b2e6cb4
+    version: 1.0.1
+  - sha: 76ee8bcd8862e4fb7c48e40fbf8110df80bd747c
+    version: 1.0.0
 ```

--- a/releases/README.md
+++ b/releases/README.md
@@ -1,0 +1,40 @@
+# Releases
+
+**NOTE** As of 2018.08 this readme is no longer current. It is left here for reference only
+---
+
+This repository stores RPC meta-releases.
+
+Each release is represented by a file in [releases/](releases).
+This file contains the name of the release, description and a list of all
+the components included in the release.
+
+## Release file specification
+Name must match the following regex: `YYYY\.MM?\.yml`
+
+The file is yaml, so should begin `---`
+
+The yaml document should be a dictionary with single top level key: **meta-release**. Meta-relase should be a dictionary with three keys:
+  * **name**: String, name of the release, should be the filename without `.yml`
+  * **description**: String, free form text describing the release
+  * **components**: List of every component included in the release
+    Each item in the list must be a dictionary with three keys:
+      * **name**: Name of the component
+      * **url**: Url to the repo or artifact for that component
+      * **version**: Version of the component included with this release.
+
+Example:
+```
+---
+  meta-release:
+    name: 2017.8
+    description: |
+      The first RPC meta-release :)
+    components:
+      - name: rpc-openstack
+        url: https://github.com/rcbops/rpc-openstack
+        version: r14.1.1
+      - name: rpc-maas
+        url: https://github.com/rcbops/rpc-maas
+        version: 1.0.0
+```


### PR DESCRIPTION
RE team agreed to stop recording information about 'meta-releases' in
the releases/ directory, and instead use the new component system
metadata files in components/

Changes:

- Move original README.md to releases/ directory
- Update root README.md to reflect information about component metadata
  files rather than the meta-release releases files