### PR TITLE
RI-376 Rename rpco's master to queens

### DIFF
--- a/components/rpc-openstack.yml
+++ b/components/rpc-openstack.yml
@@ -1,7 +1,7 @@
 is_product: true
 name: rpc-openstack
 releases:
-- series: master
+- series: queens
   versions:
   - sha: b8bde7955e682cdc0420b169005632cc25b96850
     version: r17.0.0


### PR DESCRIPTION
rpc-openstack has cut queens branches, so we should be releasing from
here goin forward.