### PR TITLE
Fix issue from rpc-maas september release

### DIFF
--- a/components/rpc-maas.yml
+++ b/components/rpc-maas.yml
@@ -3,6 +3,8 @@ name: rpc-maas
 releases:
 - series: master
   versions:
+  - sha: 037cc33aa66673b0bea6ced749d8511d1c45deb1
+    version: 1.7.7
   - sha: 2dc9c16e7f552c52fe596e47fbefdc1472c3485b
     version: 1.7.6
   - sha: f37088cdd741c4525ad807e08ef7dfda4f1f38c8


### PR DESCRIPTION
The bonding check was broken in the 1.7.6 release. A PR has been merged to resolve the issue.