### PR TITLE
Add artifact_stores to components

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ released versions of the component.
 The file is yaml, so should begin `---`
 
 The yaml document contains a number of top-level entries:
+  * **artifact_stores**: A list of artefact stores.
+      * **description**: Short explanation of the use of the artefact store.
+      * **name**: Unique name to identify the artefact store.
+      * **public_url**: URL to the artefacts.
+      * **type**: Currently only the type file is supported.
   * **is_product**: true/false
   * **name**: String, name of the component, usually the filename without `.yml`
   * **repo_url**: The URL of the repository where the code for this component is stored
@@ -26,6 +31,11 @@ The yaml document contains a number of top-level entries:
 Example:
 ```
 ---
+artifact_stores:
+- description: "Artefact used in production deployments"
+  name: release-artifacts
+  public_url: https://example.com/artefacts
+  type: file
 is_product: false
 name: rpc-component-2
 releases:

--- a/components/osp-mnaio.yml
+++ b/components/osp-mnaio.yml
@@ -1,3 +1,4 @@
+artifact_stores: []
 is_product: false
 name: osp-mnaio
 releases: []

--- a/components/rpc-ceph.yml
+++ b/components/rpc-ceph.yml
@@ -1,3 +1,4 @@
+artifact_stores: []
 is_product: true
 name: rpc-ceph
 releases:

--- a/components/rpc-component-1.yml
+++ b/components/rpc-component-1.yml
@@ -1,3 +1,4 @@
+artifact_stores: []
 is_product: false
 name: rpc-component-1
 releases:

--- a/components/rpc-component-2.yml
+++ b/components/rpc-component-2.yml
@@ -1,3 +1,4 @@
+artifact_stores: []
 is_product: false
 name: rpc-component-2
 releases:

--- a/components/rpc-hummingbird.yml
+++ b/components/rpc-hummingbird.yml
@@ -1,3 +1,4 @@
+artifact_stores: []
 is_product: true
 name: rpc-hummingbird
 releases:

--- a/components/rpc-maas.yml
+++ b/components/rpc-maas.yml
@@ -1,3 +1,4 @@
+artifact_stores: []
 is_product: false
 name: rpc-maas
 releases:

--- a/components/rpc-openstack.yml
+++ b/components/rpc-openstack.yml
@@ -1,3 +1,4 @@
+artifact_stores: []
 is_product: true
 name: rpc-openstack
 releases:

--- a/components/rpc-product-1.yml
+++ b/components/rpc-product-1.yml
@@ -1,3 +1,4 @@
+artifact_stores: []
 is_product: true
 name: rpc-product-1
 releases:

--- a/components/rpc-upgrades.yml
+++ b/components/rpc-upgrades.yml
@@ -1,3 +1,4 @@
+artifact_stores: []
 is_product: false
 name: rpc-upgrades
 releases:

--- a/gating/check/run
+++ b/gating/check/run
@@ -7,7 +7,7 @@ which python3 || { apt-get update; apt-get install -y python3-minimal; }
 
 virtualenv --python python3 .venv3
 set +x; . .venv3/bin/activate; set -x
-pip install git+https://github.com/rcbops/rpc_component@85f152ece9eee3c9cd7d68bd2ecc5982e17400ae#egg=rpc_component
+pip install git+https://github.com/rcbops/rpc_component@77f546270a6c5f01d9422c78fc4f722577c6f81d#egg=rpc_component
 
 component_count=0
 non_component_count=0


### PR DESCRIPTION
rpc_component now supports tracking artefacts, this changes updates all
component files to include the default key/value pair for this new piece
of information. The version of rpc_component used is also updated to
ensure testing continues to function.

JIRA: RE-1813

Issue: [RE-1813](https://rpc-openstack.atlassian.net/browse/RE-1813)