### PR TITLE
Add component rpc-openstack release r14.20.0

### DIFF
--- a/components/rpc-openstack.yml
+++ b/components/rpc-openstack.yml
@@ -44,6 +44,8 @@ releases:
     version: r16.0.0-beta.1
 - series: newton
   versions:
+  - sha: 912f5809689e82f5fcd5ea843f6f698eefb56991 
+    version: r14.20.0
   - sha: 20f296e9efed306e632aea37a758f7fedecf85f1
     version: r14.19.0
   - sha: 622c96a59cf762041c56307bbfe3d8224e08ea77


### PR DESCRIPTION
Update newton release.
version r14.20.0
sha 912f5809689e82f5fcd5ea843f6f698eefb56991
(https://rpc.jenkins.cit.rackspace.net/user/chun1772/my-views/view/Newton/job/PM_rpc-openstack-newton-xenial_mnaio_loose_artifacts-swift-deploy/352/)